### PR TITLE
fix: #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.0.4] - 2026-04-06
+
+### Added
+
+- Added `MacMenuBar.onSettings` API to handle the macOS Settings (Preferences) menu item.
+- Support for identifying the Settings menu item by its standard keyboard shortcut (Cmd+,).
+
+### Changed
+
+- Improved Swift code safety by using `[weak self]` in closures to prevent retain cycles.
+- Updated example app to demonstrate Settings menu handling.
+
+### Fixed
+
+- Fixed an issue where the Settings (Preferences) menu item was always disabled in the macOS application menu.
+- Resolved Swift compilation errors related to capture semantics in closures.
+
 ## [0.0.3] - 2026-02-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ void initState() {
     // Implement your select all logic here
     return true;
   });
+
+  // Handle Settings menu item (Cmd+,)
+  MacMenuBar.onSettings(() async {
+    debugPrint('Settings menu item selected');
+    // Open your app's settings dialog here
+    return true;
+  });
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add `mac_menu_bar` to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  mac_menu_bar: ^0.0.2
+  mac_menu_bar: ^0.0.4
 ```
 
 Then run `flutter pub get` to install the package.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,6 +33,15 @@ class _MyAppState extends State<MyApp> {
       debugPrint('Copy menu item selected');
       return false;
     });
+    MacMenuBar.onSettings(() async {
+      debugPrint('Settings menu item selected (Cmd+,)');
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Settings menu item selected (Cmd+,)'),
+        ),
+      );
+      return true;
+    });
     _setupCustomMenus();
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,9 +36,7 @@ class _MyAppState extends State<MyApp> {
     MacMenuBar.onSettings(() async {
       debugPrint('Settings menu item selected (Cmd+,)');
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Settings menu item selected (Cmd+,)'),
-        ),
+        const SnackBar(content: Text('Settings menu item selected (Cmd+,)')),
       );
       return true;
     });

--- a/lib/mac_menu_bar.dart
+++ b/lib/mac_menu_bar.dart
@@ -89,6 +89,21 @@ class MacMenuBar {
   static void onSelectAll(Future<bool> Function() handler) =>
       MacMenuBarPlatform.instance.setOnSelectAllFromMenu(handler);
 
+  /// Registers a callback to be invoked when the Settings/Preferences menu item is selected.
+  ///
+  /// The [handler] should return a [Future] that completes with `true` if the
+  /// operation was handled, or `false` to allow the default system behavior.
+  ///
+  /// Example:
+  /// ```dart
+  /// MacMenuBar.onSettings(() async {
+  ///   // Open settings dialog
+  ///   return true;
+  /// });
+  /// ```
+  static void onSettings(Future<bool> Function() handler) =>
+      instance.setOnSettingsFromMenu(handler);
+
   /// Adds a menu item to the specified menu.
   ///
   /// [menuId] identifies the menu to add the item to. Common menu IDs include:

--- a/lib/mac_menu_bar_method_channel.dart
+++ b/lib/mac_menu_bar_method_channel.dart
@@ -56,6 +56,12 @@ class MethodChannelMacMenuBar extends MacMenuBarPlatform {
   /// system keyboard shortcut (Cmd+A).
   Future<bool> Function()? _onSelectAll;
 
+  /// Callback for handling the Settings/Preferences menu action.
+  ///
+  /// This is called when the user selects the Settings (Preferences) menu item
+  /// or uses the system keyboard shortcut (Cmd+,).
+  Future<bool> Function()? _onSettings;
+
   /// Constructs a [MethodChannelMacMenuBar] and sets up the method call handler.
   ///
   /// This constructor initializes the method channel and sets up the handler
@@ -116,6 +122,8 @@ class MethodChannelMacMenuBar extends MacMenuBarPlatform {
         return await _onPaste?.call() ?? false;
       case 'onSelectAllFromMenu':
         return await _onSelectAll?.call() ?? false;
+      case 'onSettingsFromMenu':
+        return await _onSettings?.call() ?? false;
       case 'onMenuItemSelected':
         _handleMenuItemSelected(call.arguments);
       default:
@@ -195,6 +203,11 @@ class MethodChannelMacMenuBar extends MacMenuBarPlatform {
   @override
   void setOnSelectAllFromMenu(Future<bool> Function()? callback) {
     _onSelectAll = callback;
+  }
+
+  @override
+  void setOnSettingsFromMenu(Future<bool> Function()? callback) {
+    _onSettings = callback;
   }
 
   @override

--- a/lib/mac_menu_bar_noop.dart
+++ b/lib/mac_menu_bar_noop.dart
@@ -27,6 +27,9 @@ class MacMenuBarNoop extends MacMenuBarPlatform {
   void setOnSelectAllFromMenu(Future<bool> Function()? callback) {}
 
   @override
+  void setOnSettingsFromMenu(Future<bool> Function()? callback) {}
+
+  @override
   Future<bool> addMenuItem({
     required String menuId,
     required String itemId,

--- a/lib/mac_menu_bar_platform_interface.dart
+++ b/lib/mac_menu_bar_platform_interface.dart
@@ -80,6 +80,14 @@ abstract class MacMenuBarPlatform extends PlatformInterface {
   /// Set to `null` to restore the default system behavior.
   void setOnSelectAllFromMenu(Future<bool> Function()? callback);
 
+  /// Sets the callback that will be invoked when the Settings/Preferences menu item is selected.
+  ///
+  /// The callback should return a [Future] that completes with `true` if the
+  /// operation was handled, or `false` to allow the default system behavior.
+  ///
+  /// Set to `null` to restore the default system behavior.
+  void setOnSettingsFromMenu(Future<bool> Function()? callback);
+
   /// Adds a menu item to the specified menu.
   ///
   /// [menuId] is the identifier of the menu to add the item to (e.g., "main", "File", etc.).

--- a/lib/mac_menu_bar_web.dart
+++ b/lib/mac_menu_bar_web.dart
@@ -57,4 +57,7 @@ class MacMenuBarWebPlugin extends MacMenuBarPlatform {
 
   @override
   void setOnSelectAllFromMenu(Future<bool> Function()? callback) {}
+
+  @override
+  void setOnSettingsFromMenu(Future<bool> Function()? callback) {}
 }

--- a/macos/Classes/MacMenuBarPlugin.swift
+++ b/macos/Classes/MacMenuBarPlugin.swift
@@ -465,10 +465,19 @@ public class MacMenuBarPlugin: NSObject, FlutterPlugin {
         // Find the menu item with the specified selector
         guard let item = findMenuItem(for: selector) else { return }
         
+        overrideMenuItem(item: item, selector: selector, handler: handler)
+    }
+
+    /// Overrides a specific menu item's action with a custom handler.
+    private func overrideMenuItem(
+        item: NSMenuItem,
+        selector: Selector,
+        handler: Selector
+    ) {
         // Save the original target and selector so we can forward to it later if needed
         originalActions[selector] = OriginalAction(
             target: item.target as AnyObject?,
-            selector: selector
+            selector: item.action ?? selector
         )
         
         // Replace the target and action with our own
@@ -504,6 +513,28 @@ public class MacMenuBarPlugin: NSObject, FlutterPlugin {
             selector: #selector(NSText.selectAll(_:)),
             handler: #selector(handleSelectAll(_:))
         )
+
+        // Override the Settings/Preferences menu item
+        if let settingsItem = findSettingsMenuItem() {
+            overrideMenuItem(
+                item: settingsItem,
+                selector: #selector(handleSettings(_:)),
+                handler: #selector(handleSettings(_:))
+            )
+        }
+    }
+
+    /// Finds the Settings (Preferences) menu item by its standard keyboard shortcut (Cmd+,).
+    private func findSettingsMenuItem() -> NSMenuItem? {
+        guard let mainMenu = NSApplication.shared.mainMenu,
+              let appMenu = mainMenu.items.first?.submenu else { return nil }
+        
+        for item in appMenu.items {
+            if item.keyEquivalent == "," && item.keyEquivalentModifierMask.contains(.command) {
+                return item
+            }
+        }
+        return nil
     }
     
     /// Forwards an action to the original handler.
@@ -549,29 +580,40 @@ public class MacMenuBarPlugin: NSObject, FlutterPlugin {
     }
     
     @objc func handleCut(_ sender: Any?) {
-        channel.invokeMethod("onCutFromMenu", arguments: nil) { handled in
+        channel.invokeMethod("onCutFromMenu", arguments: nil) { [weak self] handled in
             if let didHandle = handled as? Bool, didHandle {
                 return
             }
-            self.forwardDefaultAction(#selector(NSText.cut(_:)), sender: sender)
+            self?.forwardDefaultAction(#selector(NSText.cut(_:)), sender: sender)
         }
     }
 
     @objc func handlePaste(_ sender: Any?) {
-        channel.invokeMethod("onPasteFromMenu", arguments: nil) { handled in
+        channel.invokeMethod("onPasteFromMenu", arguments: nil) { [weak self] handled in
             if let didHandle = handled as? Bool, didHandle {
                 return
             }
-            self.forwardDefaultAction(#selector(NSText.paste(_:)), sender: sender)
+            self?.forwardDefaultAction(#selector(NSText.paste(_:)), sender: sender)
         }
     }
 
     @objc func handleSelectAll(_ sender: Any?) {
-        channel.invokeMethod("onSelectAllFromMenu", arguments: nil) { handled in
+        channel.invokeMethod("onSelectAllFromMenu", arguments: nil) { [weak self] handled in
             if let didHandle = handled as? Bool, didHandle {
                 return
             }
-            self.forwardDefaultAction(#selector(NSText.selectAll(_:)), sender: sender)
+            self?.forwardDefaultAction(#selector(NSText.selectAll(_:)), sender: sender)
+        }
+    }
+
+    @objc func handleSettings(_ sender: Any?) {
+        channel.invokeMethod("onSettingsFromMenu", arguments: nil) { [weak self] handled in
+            if let didHandle = handled as? Bool, didHandle {
+                return
+            }
+            // For settings, if not handled, we don't have a standard default to forward to
+            // since it was originally unassigned in the XIB.
+            self?.forwardDefaultAction(#selector(MacMenuBarPlugin.handleSettings(_:)), sender: sender)
         }
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mac_menu_bar
 description: A Flutter plugin that provides comprehensive macOS menu bar customization and management for Flutter desktop applications.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/DeTuksa/mac_menu_bar
 
 environment:

--- a/test/mac_menu_bar_test.dart
+++ b/test/mac_menu_bar_test.dart
@@ -36,6 +36,9 @@ class MockMacMenuBarPlatform
   void setOnSelectAllFromMenu(Future<bool> Function()? callback) {}
 
   @override
+  void setOnSettingsFromMenu(Future<bool> Function()? callback) {}
+
+  @override
   void setMenuItemSelectedHandler(MenuItemSelectedHandler handler) {
     _menuItemSelectedHandler = handler;
   }


### PR DESCRIPTION
Raising a PR to resolve the issue raised:
`The Settings menu is always disabled, it would be nice if there are an option to override this menu item or set the function call in menu handler.`

- Added logic to find the Settings menu item by its standard keyboard shortcut (Command + Comma \⌘,).
- Overrode the menu item's action to forward it to Flutter via the method channel.
- Implemented handleSettings(_:) to handle the native action.
- Added MacMenuBar.onSettings(Future<bool> Function() handler) to the main API.
- Updated the platform interface and method channel implementation to support the new onSettingsFromMenu callback.
- Added no-op and web implementations to ensure cross-platform compatibility.